### PR TITLE
New API can be used to load specific app <id, key>

### DIFF
--- a/app_list.csv
+++ b/app_list.csv
@@ -1,0 +1,5 @@
+# This file can be used to list the application information (appId and appKey)
+# that will be used on the Kerberos loadAPP API. The example below must be
+# changed accordingly.
+# Format: <appId>;<appKey>
+deadbeefdeadbeef;deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef

--- a/config_all_api.sh
+++ b/config_all_api.sh
@@ -53,6 +53,7 @@ PAYLOAD
 
 ###### Configuring plugin
 
+
 curl -i -X POST \
     --url http://localhost:8001/apis/kerberos_registerComponent/plugins/ \
     --data 'name=mutualauthentication' \

--- a/loadApp.sh
+++ b/loadApp.sh
@@ -10,11 +10,22 @@
 }
 PAYLOAD
 
+# Read app list file
+export IFS=";"
+APP_ID_LIST=''
+APP_KEY_LIST=''
+while read -r APP_ID APP_KEY ; do
+    APP_ID_LIST="$APP_ID_LIST,$APP_ID"
+    APP_KEY_LIST="$APP_KEY_LIST,$APP_KEY"
+done <<< "$(grep -v '^#' app_list.csv)"
+APP_ID_LIST=${APP_ID_LIST:1}
+APP_KEY_LIST=${APP_KEY_LIST:1}
+
 curl -i -X POST \
     --url http://localhost:8001/apis/kerberos_loadApp/plugins/ \
     --data 'name=mutualauthentication' \
     --data 'config.kerberos_url=http://kerberos:8080/' \
-    --data 'config.app_id=deadbeefdeadbeef' \
-    --data 'config.app_key=deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
-      
+    --data "config.app_id=$APP_ID_LIST" \
+    --data "config.app_key=$APP_KEY_LIST"
+
 curl http://localhost:8000/kerberos/loadApp -s -S -X GET

--- a/loadApp.sh
+++ b/loadApp.sh
@@ -1,0 +1,20 @@
+# RegisterComponent
+(curl http://localhost:8001/apis -s -S -X POST \
+    --header "Content-Type: application/json" \
+    -d @- | python -m json.tool) <<PAYLOAD
+{
+    "name": "kerberos_loadApp",
+    "uris": "/kerberos/loadApp",
+    "strip_uri": true,
+    "upstream_url": "http://kerberos:8080/kerberosintegration/rest/health/status"
+}
+PAYLOAD
+
+curl -i -X POST \
+    --url http://localhost:8001/apis/kerberos_loadApp/plugins/ \
+    --data 'name=mutualauthentication' \
+    --data 'config.kerberos_url=http://kerberos:8080/' \
+    --data 'config.app_id=deadbeefdeadbeef' \
+    --data 'config.app_key=deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
+      
+curl http://localhost:8000/kerberos/loadApp -s -S -X GET

--- a/src/access.lua
+++ b/src/access.lua
@@ -49,6 +49,9 @@ function _M.run(conf)
 
     elseif(string.match(request_uri, "requestAP")) then
         handshake.requestAP(conf)
+
+    elseif(string.match(request_uri, "loadApp")) then
+        handshake.loadApp(conf)
     end
 
 end

--- a/src/schema.lua
+++ b/src/schema.lua
@@ -1,5 +1,7 @@
 return {
   fields = {
-    kerberos_url = {type = "string", required = false, defaut = "http://kerberos:8080/"}
+    kerberos_url = {type = "string", required = false, defaut = "http://kerberos:8080/"},
+    app_id = {type = "array", required = false, default = {}},
+    app_key = {type = "array", required = false, default = {}}
   }
 }

--- a/src/util.lua
+++ b/src/util.lua
@@ -45,8 +45,11 @@ function _M.hex_dump(str)
 end
 
 function _M.transform_json_body(conf, body, add_table)
+    local parameters = {}
     local content_length = (body and #body) or 0
-    local parameters = json.decode(body)
+    if content_length > 0 then
+        parameters = json.decode(body)
+    end
     if parameters == nil and content_length > 0 then
         return false, nil
     end


### PR DESCRIPTION
This new API can be used to load into Kerberos specific and predefined pairs of app_Id and app_Key without the need of directly accessing Kerberos API.
Pull requested related to issue dojot/dojot#30